### PR TITLE
Update AdviseMessage.md

### DIFF
--- a/content/mappea/reference/interfaces/AdviseMessage.md
+++ b/content/mappea/reference/interfaces/AdviseMessage.md
@@ -15,7 +15,7 @@
       "typeString": "String!",
       "name": "type",
       "url": "/mappea/reference/scalars/string",
-      "description": "Error type: The following types are valid:",
+      "description": "Error type: The following types are valid: [type]",
       "isDeprecated": true,
       "args": null,
       "deprecationReason": "",


### PR DESCRIPTION
Solicito añadir [type] en  "description": "Error type: The following types are valid: [type]", para aclarar descripción y facilitar comprensión por parte del cliente (evitando posibles aparentes contradicciones entre error-valid). OK Marcos, OK Alex Baena.