### PR TITLE
Example query is missing mandatory fields

### DIFF
--- a/content/hotel-x/howtos/bookingflow/booklist.md
+++ b/content/hotel-x/howtos/bookingflow/booklist.md
@@ -13,7 +13,7 @@
         "g":"2bee5af21dd6f2cc61eec736bb95aead",
         "o":["graphiql"],
         "u":"tgx-bot",
-        "ak":"64780338-49c8-4439-7c7d-d03c2033b145"
+        "ak":"64780338-49c8-4439-7c7d-d03c2033b145" 
     }, 
     {
         "n":"By Reference",


### PR DESCRIPTION
According to one of our clients, the query is missing the now mandatory field context. Can you please add this field to the query and remove the deprecated fields?

Thanks,

Melvin