### PR TITLE
Fix end tag of PaymentOptions

### DIFF
--- a/content/connectiontypesbuyers/legacy/methods/messages/DescriptiveInfo.md
+++ b/content/connectiontypesbuyers/legacy/methods/messages/DescriptiveInfo.md
@@ -187,7 +187,7 @@ is **180000** milliseconds.
                 <Card code="AX"/>
                 <Card code="CA"/>
             </Cards>
-        <PaymentOptions/>
+        </PaymentOptions>
         <ExclusiveDeal>true</ExclusiveDeal>
         <PropertyCategory>
              <Code>1</Code>


### PR DESCRIPTION
Corregido el tag que cierra el nodo PaymentOptions en el ejemplo de DescriptiveInfoRS