### PR TITLE
Update _index.md

### DIFF
--- a/content/travelgatex/data-automation/_index.md
+++ b/content/travelgatex/data-automation/_index.md
@@ -24,7 +24,7 @@ Our APIs have been built from the ground up with performance in mind. That means
 
 The data we must store following specificitations:
 ### HotelX
-* [Mappings](connectiontypesbuyers/hotel-x/plugins/mapping/)
-* [Custom hotel lists](connectiontypesbuyers/hotel-x/concepts/content/)
+* [Mappings](https://docs.travelgatex.com/connectiontypesbuyers/hotel-x/plugins/mapping/)
+* [Custom hotel lists](https://docs.travelgatex.com/connectiontypesbuyers/hotel-x/methods/staticcontent/)
 
 {{%custom-children%}}


### PR DESCRIPTION
Antes esta info colgaba de data-automation/ y ahora ya no es accesible. E.g.

- Antes (error page does not exist): https://docs.travelgatex.com/travelgatex/data-automation/connectiontypesbuyers/hotel-x/plugins/mapping/ 
- Ahora: https://docs.travelgatex.com/connectiontypesbuyers/hotel-x/plugins/mapping/